### PR TITLE
Use teensy4-panic crate for panic handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["{{authors}}"]
 edition = "2018"
 
 [dependencies]
-panic-halt = "0.2.0"
 cortex-m = "0.6.2"
 cortex-m-rt = "0.6.13"
 embedded-hal = "0.2.3"
+teensy4-panic = "0.1.0"
 
 [dependencies.teensy4-bsp]
 version = "0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,8 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
-
 use teensy4_bsp as bsp;
+use teensy4_panic as _;
 
 const LED_PERIOD_MS: u32 = 1_000;
 


### PR DESCRIPTION
The teensy4-panic handler is marginally more helpful than panic-halt, since it blinks the LED when there's an error. After this PR lands, new projects based on the template will depend on the custom panic handler.

See mciantyre/teensy4-rs#88 for more information on the `teensy4-panic` crate.

TODO

- [x] Publish `teensy4-panic` to crates.io.