### PR TITLE
Add boilerplate code for USB logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,12 @@ edition = "2018"
 cortex-m = "0.6.2"
 cortex-m-rt = "0.6.13"
 embedded-hal = "0.2.3"
+# Remove me if you don't want logging
+log = "0.4.11"
 teensy4-panic = "0.1.0"
 
 [dependencies.teensy4-bsp]
-version = "0.1"
+version = "0.2"
 features = ["rt"]
 
 # Don't optimize build dependencies, like proc macros.

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,52 @@
+//! USB logging support
+//!
+//! If you don't want USB logging, remove
+//!
+//! - this module
+//! - the `log` dependency in Cargo.toml
+
+use super::bsp::{self, hal::ral::usb::USB1, interrupt, usb};
+
+/// You can specify any USB logging filters here
+///
+/// See the teensy4_bsp docs for more information on
+/// logging filters.
+const FILTERS: &[usb::Filter] = &[];
+
+/// Initialize the USB logging system
+///
+/// You can only call this function once! Do it early in your
+/// program.
+///
+/// # Panics
+///
+/// Panics if the USB1 peripheral instance is already taken.
+pub fn init() {
+    assert!(usb::init(
+        USB1::take().unwrap(),
+        usb::LoggingConfig {
+            filters: FILTERS,
+            ..Default::default()
+        }
+    )
+    .is_ok());
+
+    // Safety: This call is safe as long as you use the USB
+    // interrupt handler supplied by this module. If you add
+    // any other state to the handler, you'll need to assess
+    // the safety of this call yourself.
+    unsafe { cortex_m::peripheral::NVIC::unmask(bsp::interrupt::USB_OTG1) };
+}
+
+/// Drive the USB logging system by calling `poll` in the USB
+/// interrupt handler. Without this, you might not see a USB
+/// device connected to your host.
+///
+/// # Safety
+///
+/// Users should not call this function. It will be added to the
+/// interrupt vector table, and invoked by the hardware.
+#[cortex_m_rt::interrupt]
+unsafe fn USB_OTG1() {
+    usb::poll();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> ! {
     let mut led: bsp::LED = bsp::configure_led(pins.p13);
 
     // See the `logging` module docs for more info.
-    logging::init();
+    assert!(logging::init().is_ok());
 
     loop {
         led.toggle();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,13 @@
-//! The starter code slowly blinks the LED
+//! The starter code slowly blinks the LED, and sets up
+//! USB logging.
 
 #![no_std]
 #![no_main]
 
 use teensy4_bsp as bsp;
 use teensy4_panic as _;
+
+mod logging;
 
 const LED_PERIOD_MS: u32 = 1_000;
 
@@ -15,8 +18,12 @@ fn main() -> ! {
     let pins = bsp::t40::into_pins(p.iomuxc);
     let mut led: bsp::LED = bsp::configure_led(pins.p13);
 
+    // See the `logging` module docs for more info.
+    logging::init();
+
     loop {
         led.toggle();
         systick.delay(LED_PERIOD_MS);
+        log::info!("Hello world");
     }
 }


### PR DESCRIPTION
mciantyre/teensy4-rs#91 makes it a little harder to use the BSP's USB API for logging. Before that PR, a user simply called an initialization function to enable USB logging. But now, users have to set up the USB interrupt and call a poll function to drive USB I/O. The new API is not as friendly to users who just want logging.

This PR extends the template with USB logging boilerplate. The new `logging` module will be a part of every project template, and will let the user easily enable USB logging. Users may remove the module if they have no need for logging.